### PR TITLE
Multiplayer fix + Culling

### DIFF
--- a/Source/FlickableStorage/FlickableStorage.cs
+++ b/Source/FlickableStorage/FlickableStorage.cs
@@ -28,10 +28,6 @@ namespace FlickableStorage
             targets = GenTypes.AllTypes.Where(IsHaulDestinationImplementationWithGizmos).ToList();
             var harmony = new Harmony("Mlie.FlickableStorage");
             harmony.PatchAll(Assembly.GetExecutingAssembly());
-            if (MP.enabled)
-            {
-                MP.RegisterAll();
-            }
         }
 
         private static bool IsHaulDestinationImplementationWithGizmos(Type t)

--- a/Source/FlickableStorage/IHaulDestination_GetGizmos.cs
+++ b/Source/FlickableStorage/IHaulDestination_GetGizmos.cs
@@ -36,12 +36,17 @@ namespace FlickableStorage
                 return null;
             }
 
-            if (!storageTracker.Has(destination))
+            int current;
+            if (storageTracker.Has(destination))
             {
-                storageTracker[destination] = 0;
+                current = storageTracker[destination];
+            }
+            else
+            {
+                current = 0;
             }
 
-            switch (storageTracker[destination])
+            switch (current)
             {
                 case 1:
                     return new Command_Action

--- a/Source/FlickableStorage/Multiplayer.cs
+++ b/Source/FlickableStorage/Multiplayer.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using HarmonyLib;
+using Multiplayer.API;
+using RimWorld;
+using Verse;
+
+namespace FlickableStorage
+{
+    [StaticConstructorOnStartup]
+    static class Multiplayer
+    {
+        static Multiplayer()
+        {
+            if (!MP.enabled) return;
+
+            MP.RegisterSyncWorker<IHaulDestination>(IHaulDestinationWorker);
+            MP.RegisterSyncMethod(AccessTools.Method(typeof(StorageTracker), "set_Item"));
+        }
+
+        private static void IHaulDestinationWorker(SyncWorker sync, ref IHaulDestination destination)
+        {
+            if (sync.isWriting)
+            {
+                sync.Write(destination.Map);
+                sync.Write(destination.Position);
+            }
+            else
+            {
+                var map = sync.Read<Map>();
+                var pos = sync.Read<IntVec3>();
+
+                destination = map.haulDestinationManager.AllHaulDestinationsListForReading
+                              .FirstOrDefault(d => d.Position == pos);
+            }
+        }
+    }
+}

--- a/Source/FlickableStorage/StorageTracker.cs
+++ b/Source/FlickableStorage/StorageTracker.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using RimWorld;
 using Verse;
 
@@ -29,7 +30,24 @@ namespace FlickableStorage
         public override void ExposeData()
         {
             base.ExposeData();
+            if (Scribe.mode == LoadSaveMode.Saving)
+            {
+                Cull();
+            }
             Scribe_Collections.Look(ref haulDestinations, "StockpileStatuses", LookMode.Reference, LookMode.Value, ref tmpHaulDestinationsKeys, ref tmpHaulDestinationValues);
+        }
+
+        private void Cull()
+        {
+            foreach (var destination in haulDestinations.Keys.ToList()) 
+            {
+                var inPlace = map.haulDestinationManager.AllHaulDestinations
+                              .FirstOrDefault(d => d.Position == destination.Position);
+                if (inPlace != destination || haulDestinations[destination] == 0)
+                {
+                    haulDestinations.Remove(destination);
+                }
+            }
         }
     }
 }

--- a/Source/FlickableStorage/StorageTracker.cs
+++ b/Source/FlickableStorage/StorageTracker.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Multiplayer.API;
 using RimWorld;
 using Verse;
 
@@ -19,7 +18,7 @@ namespace FlickableStorage
         public int this[IHaulDestination destination]
         {
             get => haulDestinations[destination];
-            [SyncMethod] set => haulDestinations[destination] = value;
+            set => haulDestinations[destination] = value;
         }
 
         public bool Has(IHaulDestination zone)


### PR DESCRIPTION
Generalizing it broke the Multiplayer part. This is the fix.

Also, added a method for culling the StorageTracker Dictionary, so it doesn't endlessly fill and cause bloat. Prunes on save.